### PR TITLE
fix: update defaultTheme to 'light' in RootLayout component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <ThemeProvider
           attribute='class'
-          defaultTheme='system'
+          defaultTheme='light'
           enableColorScheme
           disableTransitionOnChange
           enableSystem


### PR DESCRIPTION
o `defaultTheme` estava como system, e caso o usuário estivesse com o tema dark no navegador (como eu), o layout da landing page ficava com as cores invertidas:

![www leafpallete com_](https://github.com/user-attachments/assets/aa370041-8873-46c4-b03b-20edd185aed9)

fiz a alteração definindo o defaultTheme para light, enquanto usamos a landing page provisória.