### PR TITLE
Add Leafy Bot reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ Feito! Agora vá para a página do repositório no GitHub e clique no botão **C
 ## 📝 Licença
 
 Este projeto está licenciado sob a Licença MIT. Veja o arquivo [LICENSE](LICENSE.md) para mais detalhes.
+
+
+## 🤖 Leafy Bot
+
+Para aumentar o engajamento da nossa comunidade, criamos o Leafy Bot, um bot do Discord dedicado a ajudar e interagir com nossos membros. Confira o Leafy Bot e contribua para o seu desenvolvimento em nosso [repositório no GitHub](https://github.com/Leaf-Pallete/leafy-bot).


### PR DESCRIPTION
This PR adds information about Leafy, our Discord bot, to the project README. Leafy is designed to assist and engage with our community members. 

Changes made:
- Added a link to Leafy's GitHub repository

Leafy Bot is an open-source project that we're developing as part of the Leaf Palette organization. By adding this reference to our main README, we aim to:
1. Increase visibility of the bot project
2. Encourage community contributions to Leafy's development

The Leafy Bot repository can be found at: https://github.com/Leaf-Pallete/leafy-bot

We welcome feedback and contributions from the community to help make Leafy an invaluable tool for our Discord members.